### PR TITLE
Fix up time fields

### DIFF
--- a/gdcdictionary/examples/valid/demographic.json
+++ b/gdcdictionary/examples/valid/demographic.json
@@ -1,16 +1,13 @@
 {
     "gender": "male",
     "submitter_id": "E9EDB78B-6897-4205-B9AA-0CEF8AAB5A1F_demographic",
-    "days_to_birth":-12414,
-    "days_to_death":1241,
     "cause_of_death":"Disease Related",
     "vital_status":"Dead",
-    "year_of_birth": 1652,
     "race": "white",
     "cases": {
         "submitter_id": "BLGSP-71-06-00019"
     },
     "type": "demographic",
     "ethnicity": "not hispanic or latino",
-    "year_of_death": 2009
+    "age_at_last_follow_up_days" : 1000
 }

--- a/gdcdictionary/examples/valid/diagnosis.json
+++ b/gdcdictionary/examples/valid/diagnosis.json
@@ -1,11 +1,9 @@
 {
     "type": "diagnosis",
     "submitter_id": "E9EDB78B-6897-4205-B9AA-0CEF8AAB5A1F_diagnosis",
-    "age_at_diagnosis": 47,
-    "days_to_death": 1241,
+    "age_at_diagnosis_days": 470,
     "primary_diagnosis": "Atrial septal defect",
     "primary_anatomic_site": "UBERON:0002085",
-    "vital_status": "dead",
     "cases": {
         "submitter_id": "BLGSP-71-06-00019"
     }

--- a/gdcdictionary/schemas/_terms.yaml
+++ b/gdcdictionary/schemas/_terms.yaml
@@ -44,7 +44,7 @@ adverse_event:
     cde_version: 1.1
     term_url: "https://cdebrowser.nci.nih.gov/cdebrowserClient/cdeBrowser.html#/search?publicId=3125302&version=1.1"
 
-age_at_diagnosis:
+age_at_diagnosis_days:
   description: >
     Age at the time of diagnosis expressed in number of days since birth.
   termDef:
@@ -53,6 +53,16 @@ age_at_diagnosis:
     cde_id: 3225640
     cde_version: 2.0
     term_url: "https://cdebrowser.nci.nih.gov/cdebrowserClient/cdeBrowser.html#/search?publicId=3225640&version=2.0"
+
+age_at_last_follow_up_days:
+  description: >
+    The age in days at the last follow-up or death of the patient.
+  termDef:
+    term: null
+    source: null
+    cde_id: null
+    cde_version: null
+    term_url: null
 
 ajcc_clinical_m:
   description: >
@@ -1439,15 +1449,15 @@ oct_embedded:
     cde_version: 1.0
     term_url: "https://cdebrowser.nci.nih.gov/cdebrowserClient/cdeBrowser.html#/search?publicId=5432538&version=1.0"
 
-overall_survival:
+overall_survival_time_days:
   description: >
-    Number of days between the date used for index and the patient's date of death or the date the patient was last known to be alive.
+    The number of days after diagnosis to the last follow-up or death of the patient.
   termDef:
-    term: null
-    source: null
-    cde_id: null
-    cde_version: null
-    term_url: null
+    term: Diagnosis To Last Communication Contact Time Day Count
+    source: caDSR
+    cde_id: 3226269
+    cde_version: 1.0
+    term_url: "https://cdebrowser.nci.nih.gov/cdebrowserClient/cdeBrowser.html#/search?publicId=3226269&version=1.0"
 
 pack_years_smoked:
   description: >

--- a/gdcdictionary/schemas/demographic.yaml
+++ b/gdcdictionary/schemas/demographic.yaml
@@ -54,15 +54,14 @@ properties:
       - Not Reported
       - Unknown
 
-  days_to_birth:
+  age_at_last_follow_up_days:
     term:
-      $ref: "_terms.yaml#/days_to_birth"
-    type: integer
-
-  days_to_death:
-    term:
-      $ref: "_terms.yaml#/days_to_death"
-    type: integer
+      $ref: "_terms.yaml#/age_at_last_follow_up_days"
+    type:
+      - integer
+      - "null"
+    maximum: 32872
+    minimum: 0
 
   gender:
     term:
@@ -97,18 +96,6 @@ properties:
       - Unknown
       - not reported
       - not allowed to collect
-
-  year_of_birth:
-    term:
-      $ref: "_terms.yaml#/year_of_birth"
-    type:
-      - number
-      - "null"
-
-  year_of_death:
-    term:
-      $ref: "_terms.yaml#/year_of_death"
-    type: number
 
   vital_status:
     term:

--- a/gdcdictionary/schemas/diagnosis.yaml
+++ b/gdcdictionary/schemas/diagnosis.yaml
@@ -30,10 +30,9 @@ links:
     required: true
 
 required:
-  - age_at_diagnosis
+  - age_at_diagnosis_days
   - primary_diagnosis
   - primary_anatomic_site
-  - vital_status
 
 uniqueKeys:
   #unclear if want submitter ID for clinical
@@ -43,35 +42,14 @@ uniqueKeys:
 properties:
   $ref_ubiq: "_definitions.yaml#/ubiquitous_properties"
   
-  age_at_diagnosis:
+  age_at_diagnosis_days:
     term:
-      $ref: "_terms.yaml#/age_at_diagnosis"
+      $ref: "_terms.yaml#/age_at_diagnosis_days"
     type:
-      - number
+      - integer
       - "null"
     maximum: 32872
     minimum: 0
-
-  days_to_death:
-    term:
-      $ref: "_terms.yaml#/days_to_death"
-    type: number
-    maximum: 32872
-    minimum: 0
-
-  days_to_last_follow_up:
-    term:
-      $ref: "_terms.yaml#/days_to_last_follow_up"
-    type:
-      - number
-      - "null"
-
-  days_to_last_known_disease_status:
-    term:
-      $ref: "_terms.yaml#/days_to_last_known_disease_status"
-    type:
-      - number
-      - "null"
 
   primary_anatomic_site:
     term:
@@ -85,14 +63,5 @@ properties:
       $ref: "_terms.yaml#/primary_diagnosis"
     type: string
 
-  vital_status:
-    term:
-      $ref: "_terms.yaml#/vital_status"
-    enum:
-      - alive
-      - dead
-      - lost to follow-up
-      - unknown
-      - not reported
   cases:
     $ref: "_definitions.yaml#/to_one"


### PR DESCRIPTION
- remove all "year" fields
- change everything to "age_at"
- add "days" to field names for clarity
- vital_status and related age_at_last_follow_up_days on demographic instead of diagnosis as only single value per case

closes #58 

cc @junjun-zhang 